### PR TITLE
Add AI-powered receipt management app

### DIFF
--- a/IAhorro/ContentView.swift
+++ b/IAhorro/ContentView.swift
@@ -9,13 +9,7 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
-        }
-        .padding()
+        Text("IAhorro se inicia desde IAhorroApp.swift")
     }
 }
 

--- a/IAhorro/IAhorroApp.swift
+++ b/IAhorro/IAhorroApp.swift
@@ -9,9 +9,53 @@ import SwiftUI
 
 @main
 struct IAhorroApp: App {
+    @State private var environment: AppEnvironment?
+    @State private var initializationError: Error?
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            Group {
+                if let environment {
+                    RootView(
+                        answerService: environment.answerService,
+                        processingService: environment.processingService,
+                        receiptStore: environment.receiptStore
+                    )
+                    .environmentObject(environment.receiptStore)
+                } else if let initializationError {
+                    VStack(spacing: 16) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .font(.largeTitle)
+                        Text("No se pudo inicializar la aplicación.")
+                            .font(.headline)
+                        Text(initializationError.localizedDescription)
+                            .font(.subheadline)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal)
+                        Button("Reintentar") {
+                            Task { await loadEnvironment() }
+                        }
+                    }
+                    .padding()
+                } else {
+                    ProgressView("Preparando IAhorro…")
+                }
+            }
+            .task {
+                if environment == nil && initializationError == nil {
+                    await loadEnvironment()
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func loadEnvironment() async {
+        do {
+            environment = try await AppEnvironment.make()
+            initializationError = nil
+        } catch {
+            initializationError = error
         }
     }
 }

--- a/IAhorro/Models/Receipt.swift
+++ b/IAhorro/Models/Receipt.swift
@@ -1,0 +1,146 @@
+import Foundation
+/// Represents a single receipt captured or imported by the user.
+struct Receipt: Identifiable, Codable, Hashable {
+    enum MediaType: String, Codable {
+        case image
+        case pdf
+    }
+
+    struct TaxBreakdown: Codable, Hashable {
+        var subtotal: Decimal?
+        var tax: Decimal?
+        var total: Decimal?
+
+        init(subtotal: Decimal? = nil, tax: Decimal? = nil, total: Decimal? = nil) {
+            self.subtotal = subtotal
+            self.tax = tax
+            self.total = total
+        }
+    }
+
+    struct Party: Codable, Hashable {
+        var name: String?
+        var contact: String?
+        var address: String?
+    }
+
+    struct LineItem: Codable, Hashable, Identifiable {
+        var id: UUID
+        var description: String
+        var quantity: Double?
+        var unitPrice: Decimal?
+        var total: Decimal?
+
+        init(id: UUID = UUID(), description: String, quantity: Double? = nil, unitPrice: Decimal? = nil, total: Decimal? = nil) {
+            self.id = id
+            self.description = description
+            self.quantity = quantity
+            self.unitPrice = unitPrice
+            self.total = total
+        }
+    }
+
+    var id: UUID
+    var createdAt: Date
+    var purchaseDate: Date?
+    var merchant: Party
+    var payer: Party
+    var taxBreakdown: TaxBreakdown
+    var currencyCode: String
+    var mediaType: MediaType
+    var fileName: String
+    var fileURL: URL
+    var thumbnailURL: URL?
+    var userDescription: String?
+    var location: Geolocation?
+    var keywords: [String]
+    var categories: [ReceiptCategory]
+    var lineItems: [LineItem]
+    var notes: String?
+
+    init(
+        id: UUID = UUID(),
+        createdAt: Date = .init(),
+        purchaseDate: Date? = nil,
+        merchant: Party = .init(),
+        payer: Party = .init(),
+        taxBreakdown: TaxBreakdown = .init(),
+        currencyCode: String = Locale.current.currency?.identifier ?? "USD",
+        mediaType: MediaType,
+        fileName: String,
+        fileURL: URL,
+        thumbnailURL: URL? = nil,
+        userDescription: String? = nil,
+        location: Geolocation? = nil,
+        keywords: [String] = [],
+        categories: [ReceiptCategory] = [],
+        lineItems: [LineItem] = [],
+        notes: String? = nil
+    ) {
+        self.id = id
+        self.createdAt = createdAt
+        self.purchaseDate = purchaseDate
+        self.merchant = merchant
+        self.payer = payer
+        self.taxBreakdown = taxBreakdown
+        self.currencyCode = currencyCode
+        self.mediaType = mediaType
+        self.fileName = fileName
+        self.fileURL = fileURL
+        self.thumbnailURL = thumbnailURL
+        self.userDescription = userDescription
+        self.location = location
+        self.keywords = keywords
+        self.categories = categories
+        self.lineItems = lineItems
+        self.notes = notes
+    }
+}
+
+extension Receipt {
+    /// Returns the effective total for the receipt prioritising explicit total, subtotal+tax, then the sum of line items.
+    var effectiveTotal: Decimal? {
+        if let total = taxBreakdown.total {
+            return total
+        }
+        if let subtotal = taxBreakdown.subtotal, let tax = taxBreakdown.tax {
+            return subtotal + tax
+        }
+        let lineTotals = lineItems.compactMap(\.total)
+        if lineTotals.isEmpty {
+            return nil
+        }
+        return lineTotals.reduce(Decimal(0), +)
+    }
+}
+
+struct ReceiptCategory: Codable, Identifiable, Hashable {
+    var id: String { rawValue }
+    let rawValue: String
+    let displayName: String
+    let iconSystemName: String
+
+    static let basics = ReceiptCategory(rawValue: "basics", displayName: "Gastos básicos", iconSystemName: "house.fill")
+    static let rent = ReceiptCategory(rawValue: "rent", displayName: "Arriendo", iconSystemName: "building.2.fill")
+    static let groceries = ReceiptCategory(rawValue: "groceries", displayName: "Supermercado", iconSystemName: "cart.fill")
+    static let dining = ReceiptCategory(rawValue: "dining", displayName: "Comidas", iconSystemName: "fork.knife")
+    static let fastFood = ReceiptCategory(rawValue: "fast-food", displayName: "Comida chatarra", iconSystemName: "takeoutbag.and.cup.and.straw.fill")
+    static let entertainment = ReceiptCategory(rawValue: "entertainment", displayName: "Ocio", iconSystemName: "gamecontroller.fill")
+    static let health = ReceiptCategory(rawValue: "health", displayName: "Salud", iconSystemName: "cross.case.fill")
+    static let transport = ReceiptCategory(rawValue: "transport", displayName: "Transporte", iconSystemName: "car.fill")
+    static let education = ReceiptCategory(rawValue: "education", displayName: "Educación", iconSystemName: "book.fill")
+    static let other = ReceiptCategory(rawValue: "other", displayName: "Otros", iconSystemName: "tray.full.fill")
+
+    static let predefined: [ReceiptCategory] = [
+        .basics, .rent, .groceries, .dining, .fastFood, .entertainment, .health, .transport, .education, .other
+    ]
+}
+
+struct Geolocation: Codable, Hashable {
+    var latitude: Double
+    var longitude: Double
+}
+
+extension Array where Element == ReceiptCategory {
+    static var defaultForAI: [ReceiptCategory] { ReceiptCategory.predefined }
+}

--- a/IAhorro/Models/ReceiptAnalysis.swift
+++ b/IAhorro/Models/ReceiptAnalysis.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Result returned by the OpenAI analysis endpoint once a receipt image or PDF has been processed.
+struct ReceiptAnalysisResult: Codable {
+    struct Party: Codable {
+        var name: String?
+        var contact: String?
+        var address: String?
+    }
+
+    struct TaxBreakdown: Codable {
+        var subtotal: Decimal?
+        var tax: Decimal?
+        var total: Decimal?
+    }
+
+    struct LineItem: Codable {
+        var description: String
+        var quantity: Double?
+        var unitPrice: Decimal?
+        var total: Decimal?
+    }
+
+    var merchant: Party
+    var payer: Party
+    var purchaseDate: Date?
+    var taxBreakdown: TaxBreakdown
+    var currencyCode: String?
+    var keywords: [String]
+    var categories: [String]
+    var lineItems: [LineItem]
+    var notes: String?
+    var aiSummary: String?
+
+    init(
+        merchant: Party = .init(),
+        payer: Party = .init(),
+        purchaseDate: Date? = nil,
+        taxBreakdown: TaxBreakdown = .init(),
+        currencyCode: String? = nil,
+        keywords: [String] = [],
+        categories: [String] = [],
+        lineItems: [LineItem] = [],
+        notes: String? = nil,
+        aiSummary: String? = nil
+    ) {
+        self.merchant = merchant
+        self.payer = payer
+        self.purchaseDate = purchaseDate
+        self.taxBreakdown = taxBreakdown
+        self.currencyCode = currencyCode
+        self.keywords = keywords
+        self.categories = categories
+        self.lineItems = lineItems
+        self.notes = notes
+        self.aiSummary = aiSummary
+    }
+}
+
+struct ReceiptInsight: Codable {
+    var totalSpent: Decimal
+    var categories: [String: Decimal]
+    var keywords: [String]
+    var summary: String
+}

--- a/IAhorro/Services/FallbackAIService.swift
+++ b/IAhorro/Services/FallbackAIService.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+struct FallbackAIService: ReceiptAnalyzing, ReceiptAnswering {
+    func analyzeReceipt(mediaData: Data, mediaType: Receipt.MediaType, userDescription: String?, location: Geolocation?) async throws -> ReceiptAnalysisResult {
+        let keywords = (userDescription ?? "")
+            .lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+        let categories = inferCategories(from: keywords)
+        return ReceiptAnalysisResult(
+            merchant: .init(name: "Comercio desconocido", contact: nil, address: nil),
+            payer: .init(name: nil, contact: nil, address: nil),
+            purchaseDate: Date(),
+            taxBreakdown: .init(subtotal: nil, tax: nil, total: nil),
+            currencyCode: Locale.current.currency?.identifier,
+            keywords: keywords,
+            categories: categories,
+            lineItems: [],
+            notes: userDescription,
+            aiSummary: "Boleta capturada sin análisis IA en modo sin conexión"
+        )
+    }
+
+    func answerQuestion(query: String, receipts: [Receipt]) async throws -> String {
+        let total = receipts.compactMap(\.effectiveTotal).reduce(Decimal(0), +)
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = receipts.first?.currencyCode ?? Locale.current.currency?.identifier
+        let totalText = formatter.string(from: NSDecimalNumber(decimal: total)) ?? "-"
+        let titles = receipts.map { receipt in
+            "• \(receipt.merchant.name ?? "Comercio") - \(receipt.purchaseDate?.formatted(date: .abbreviated, time: .omitted) ?? "fecha desconocida")"
+        }
+        return [
+            "Resumen sin conexión",
+            "Total estimado: \(totalText)",
+            "Coincidencias: \n\(titles.joined(separator: "\n"))"
+        ].joined(separator: "\n\n")
+    }
+
+    private func inferCategories(from keywords: [String]) -> [String] {
+        let mapping: [String: String] = [
+            "medic": "health",
+            "salud": "health",
+            "doctor": "health",
+            "super": "groceries",
+            "comida": "dining",
+            "arriendo": "rent",
+            "ocio": "entertainment"
+        ]
+        var matched: Set<String> = []
+        for keyword in keywords {
+            for (pattern, category) in mapping where keyword.contains(pattern) {
+                matched.insert(category)
+            }
+        }
+        if matched.isEmpty {
+            matched.insert(ReceiptCategory.other.rawValue)
+        }
+        return Array(matched)
+    }
+}

--- a/IAhorro/Services/OpenAIService.swift
+++ b/IAhorro/Services/OpenAIService.swift
@@ -1,0 +1,203 @@
+import Foundation
+import UIKit
+
+struct OpenAIConfiguration {
+    var apiKey: String
+    var organization: String?
+    var baseURL: URL
+
+    init(apiKey: String, organization: String? = nil, baseURL: URL = URL(string: "https://api.openai.com/v1")!) {
+        self.apiKey = apiKey
+        self.organization = organization
+        self.baseURL = baseURL
+    }
+
+    static func loadFromInfoPlist() -> OpenAIConfiguration? {
+        guard let dict = Bundle.main.infoDictionary,
+              let key = dict["OPENAI_API_KEY"] as? String,
+              !key.isEmpty else { return nil }
+        let organization = dict["OPENAI_ORG_ID"] as? String
+        return .init(apiKey: key, organization: organization)
+    }
+}
+
+protocol ReceiptAnalyzing {
+    func analyzeReceipt(mediaData: Data, mediaType: Receipt.MediaType, userDescription: String?, location: Geolocation?) async throws -> ReceiptAnalysisResult
+}
+
+protocol ReceiptAnswering {
+    func answerQuestion(query: String, receipts: [Receipt]) async throws -> String
+}
+
+final class OpenAIService {
+    enum ServiceError: LocalizedError {
+        case missingConfiguration
+        case unexpectedResponse
+        case decodingFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .missingConfiguration:
+                return "No se encontró la configuración de OpenAI."
+            case .unexpectedResponse:
+                return "La respuesta del servicio de IA no es válida."
+            case .decodingFailed:
+                return "No se pudo decodificar la respuesta del servicio de IA."
+            }
+        }
+    }
+
+    private let configuration: OpenAIConfiguration
+    private let session: URLSession
+
+    init(configuration: OpenAIConfiguration? = OpenAIConfiguration.loadFromInfoPlist(), session: URLSession = .shared) throws {
+        guard let configuration else {
+            throw ServiceError.missingConfiguration
+        }
+        self.configuration = configuration
+        self.session = session
+    }
+
+    // MARK: - Public API
+
+    func analyzeReceipt(mediaData: Data, mediaType: Receipt.MediaType, userDescription: String?, location: Geolocation?) async throws -> ReceiptAnalysisResult {
+        let boundary = UUID().uuidString
+        var request = URLRequest(url: configuration.baseURL.appendingPathComponent("/assistants/receipts:analyze"))
+        request.httpMethod = "POST"
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(configuration.apiKey)", forHTTPHeaderField: "Authorization")
+        if let organization = configuration.organization {
+            request.setValue(organization, forHTTPHeaderField: "OpenAI-Organization")
+        }
+
+        let body = try buildMultipartBody(
+            boundary: boundary,
+            mediaData: mediaData,
+            mediaType: mediaType,
+            userDescription: userDescription,
+            location: location
+        )
+        request.httpBody = body
+
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, 200..<300 ~= httpResponse.statusCode else {
+            throw ServiceError.unexpectedResponse
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        do {
+            return try decoder.decode(ReceiptAnalysisResult.self, from: data)
+        } catch {
+            throw ServiceError.decodingFailed
+        }
+    }
+
+    func answerQuestion(query: String, receipts: [Receipt]) async throws -> String {
+        var request = URLRequest(url: configuration.baseURL.appendingPathComponent("/chat/completions"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(configuration.apiKey)", forHTTPHeaderField: "Authorization")
+        if let organization = configuration.organization {
+            request.setValue(organization, forHTTPHeaderField: "OpenAI-Organization")
+        }
+
+        let prompt = buildQueryPrompt(query: query, receipts: receipts)
+        let payload = ChatCompletionPayload(model: "gpt-4o-mini", messages: prompt)
+        request.httpBody = try JSONEncoder().encode(payload)
+
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, 200..<300 ~= httpResponse.statusCode else {
+            throw ServiceError.unexpectedResponse
+        }
+        let completion = try JSONDecoder().decode(ChatCompletionResponse.self, from: data)
+        guard let message = completion.choices.first?.message.content else {
+            throw ServiceError.unexpectedResponse
+        }
+        return message
+    }
+
+    // MARK: - Multipart helpers
+
+    private func buildMultipartBody(boundary: String, mediaData: Data, mediaType: Receipt.MediaType, userDescription: String?, location: Geolocation?) throws -> Data {
+        var body = Data()
+        let lineBreak = "\r\n"
+        var metadata: [String: Any] = [
+            "media_type": mediaType.rawValue
+        ]
+        if let userDescription, !userDescription.isEmpty {
+            metadata["user_description"] = userDescription
+        }
+        if let location {
+            metadata["location"] = ["latitude": location.latitude, "longitude": location.longitude]
+        }
+
+        let metadataData = try JSONSerialization.data(withJSONObject: metadata, options: .prettyPrinted)
+
+        body.appendString("--\(boundary)\r\n")
+        body.appendString("Content-Disposition: form-data; name=\"metadata\"\r\n")
+        body.appendString("Content-Type: application/json\r\n\r\n")
+        body.append(metadataData)
+        body.appendString(lineBreak)
+
+        let filename = "receipt.\(mediaType == .pdf ? "pdf" : "jpg")"
+        let mimeType = mediaType == .pdf ? "application/pdf" : "image/jpeg"
+
+        body.appendString("--\(boundary)\r\n")
+        body.appendString("Content-Disposition: form-data; name=\"file\"; filename=\"\(filename)\"\r\n")
+        body.appendString("Content-Type: \(mimeType)\r\n\r\n")
+        body.append(mediaData)
+        body.appendString(lineBreak)
+        body.appendString("--\(boundary)--\r\n")
+        return body
+    }
+
+    private func buildQueryPrompt(query: String, receipts: [Receipt]) -> [ChatMessage] {
+        let systemMessage = ChatMessage(role: "system", content: "Eres un asistente financiero que responde en español con resúmenes claros y cálidos. Usa las boletas proporcionadas para responder.")
+        let contextBlocks = receipts.map { receipt -> String in
+            let formatter = ISO8601DateFormatter()
+            let purchaseDate = receipt.purchaseDate.flatMap { formatter.string(from: $0) } ?? "desconocida"
+            let total = receipt.effectiveTotal?.description ?? "-"
+            let categories = receipt.categories.map(\.displayName).joined(separator: ", ")
+            return "Boleta #\(receipt.id.uuidString) | Comercio: \(receipt.merchant.name ?? "-") | Fecha: \(purchaseDate) | Total: \(total) \(receipt.currencyCode) | Categorías: \(categories) | Palabras clave: \(receipt.keywords.joined(separator: ", ")) | Notas: \(receipt.notes ?? "-" )"
+        }
+
+        let userContent = (["Consulta: \(query)"] + contextBlocks).joined(separator: "\n")
+        let userMessage = ChatMessage(role: "user", content: userContent)
+        return [systemMessage, userMessage]
+    }
+}
+
+extension OpenAIService: ReceiptAnalyzing, ReceiptAnswering {}
+
+// MARK: - Chat Completion Payload
+
+private struct ChatCompletionPayload: Encodable {
+    struct Message: Encodable {
+        var role: String
+        var content: String
+    }
+
+    var model: String
+    var messages: [ChatMessage]
+}
+
+private struct ChatCompletionResponse: Decodable {
+    struct Choice: Decodable {
+        var message: ChatMessage
+    }
+
+    var choices: [Choice]
+}
+
+struct ChatMessage: Codable {
+    var role: String
+    var content: String
+}
+
+private extension Data {
+    mutating func appendString(_ string: String) {
+        if let data = string.data(using: .utf8) {
+            append(data)
+        }
+    }
+}

--- a/IAhorro/Services/ReceiptProcessingService.swift
+++ b/IAhorro/Services/ReceiptProcessingService.swift
@@ -1,0 +1,139 @@
+import Foundation
+import UIKit
+import CoreGraphics
+
+struct ProcessedReceipt {
+    let receipt: Receipt
+    let fileData: Data
+    let thumbnail: UIImage?
+}
+
+protocol ReceiptProcessingServiceProtocol {
+    func process(mediaData: Data, mediaType: Receipt.MediaType, originalFileName: String, userDescription: String?, location: Geolocation?) async throws -> ProcessedReceipt
+}
+
+final class ReceiptProcessingService: ReceiptProcessingServiceProtocol {
+    private let analyzer: ReceiptAnalyzing
+    private let thumbnailGenerator: ThumbnailGenerating
+
+    init(analyzer: ReceiptAnalyzing, thumbnailGenerator: ThumbnailGenerating = DefaultThumbnailGenerator()) {
+        self.analyzer = analyzer
+        self.thumbnailGenerator = thumbnailGenerator
+    }
+
+    func process(mediaData: Data, mediaType: Receipt.MediaType, originalFileName: String, userDescription: String?, location: Geolocation?) async throws -> ProcessedReceipt {
+        let analysis = try await analyzer.analyzeReceipt(mediaData: mediaData, mediaType: mediaType, userDescription: userDescription, location: location)
+        let categories = mapCategories(analysis.categories)
+        let keywords = enrichKeywords(analysis.keywords, userDescription: userDescription)
+        let taxBreakdown = Receipt.TaxBreakdown(
+            subtotal: analysis.taxBreakdown.subtotal,
+            tax: analysis.taxBreakdown.tax,
+            total: analysis.taxBreakdown.total
+        )
+
+        let fileName = uniqueFileName(from: originalFileName, mediaType: mediaType)
+        var receipt = Receipt(
+            purchaseDate: analysis.purchaseDate,
+            merchant: .init(name: analysis.merchant.name, contact: analysis.merchant.contact, address: analysis.merchant.address),
+            payer: .init(name: analysis.payer.name, contact: analysis.payer.contact, address: analysis.payer.address),
+            taxBreakdown: taxBreakdown,
+            currencyCode: analysis.currencyCode ?? Locale.current.currency?.identifier ?? "USD",
+            mediaType: mediaType,
+            fileName: fileName,
+            fileURL: URL(fileURLWithPath: ""),
+            userDescription: userDescription,
+            location: location,
+            keywords: keywords,
+            categories: categories,
+            lineItems: analysis.lineItems.map { item in
+                Receipt.LineItem(description: item.description, quantity: item.quantity, unitPrice: item.unitPrice, total: item.total)
+            },
+            notes: analysis.notes ?? analysis.aiSummary
+        )
+
+        let thumbnail = try await thumbnailGenerator.makeThumbnail(from: mediaData, mediaType: mediaType)
+        let normalizedData = try normalize(mediaData: mediaData, mediaType: mediaType)
+        return ProcessedReceipt(receipt: receipt, fileData: normalizedData, thumbnail: thumbnail)
+    }
+
+    private func normalize(mediaData: Data, mediaType: Receipt.MediaType) throws -> Data {
+        switch mediaType {
+        case .image:
+            guard let image = UIImage(data: mediaData) else { return mediaData }
+            guard let jpegData = image.jpegData(compressionQuality: 0.92) else { return mediaData }
+            return jpegData
+        case .pdf:
+            return mediaData
+        }
+    }
+
+    private func uniqueFileName(from original: String, mediaType: Receipt.MediaType) -> String {
+        let sanitized = original.replacingOccurrences(of: "[^A-Za-z0-9._-]", with: "_", options: .regularExpression)
+        let ext = (mediaType == .pdf) ? "pdf" : "jpg"
+        if sanitized.isEmpty {
+            return "receipt-\(UUID().uuidString).\(ext)"
+        }
+        if sanitized.lowercased().hasSuffix(".\(ext)") {
+            return sanitized
+        }
+        return "\(sanitized).\(ext)"
+    }
+
+    private func mapCategories(_ categories: [String]) -> [ReceiptCategory] {
+        let normalized = categories.map { $0.lowercased() }
+        let mapping = Dictionary(uniqueKeysWithValues: ReceiptCategory.predefined.map { ($0.rawValue, $0) })
+        var result: [ReceiptCategory] = []
+        for category in normalized {
+            if let mapped = mapping[category] {
+                result.append(mapped)
+            } else if let fuzzy = mapping.values.first(where: { category.contains($0.rawValue) || $0.rawValue.contains(category) }) {
+                result.append(fuzzy)
+            }
+        }
+        if result.isEmpty {
+            result.append(.other)
+        }
+        return Array(Set(result)).sorted(by: { $0.displayName < $1.displayName })
+    }
+
+    private func enrichKeywords(_ keywords: [String], userDescription: String?) -> [String] {
+        var combined = Set(keywords.map { $0.lowercased() })
+        if let userDescription {
+            let descriptionKeywords = userDescription
+                .lowercased()
+                .components(separatedBy: CharacterSet.alphanumerics.inverted)
+                .filter { !$0.isEmpty && $0.count > 2 }
+            combined.formUnion(descriptionKeywords)
+        }
+        return combined.sorted()
+    }
+}
+
+// MARK: - Thumbnail Generation
+
+protocol ThumbnailGenerating {
+    func makeThumbnail(from data: Data, mediaType: Receipt.MediaType) async throws -> UIImage?
+}
+
+struct DefaultThumbnailGenerator: ThumbnailGenerating {
+    func makeThumbnail(from data: Data, mediaType: Receipt.MediaType) async throws -> UIImage? {
+        switch mediaType {
+        case .image:
+            return UIImage(data: data)
+        case .pdf:
+            guard let provider = CGDataProvider(data: data as CFData), let document = CGPDFDocument(provider) else { return nil }
+            guard let page = document.page(at: 1) else { return nil }
+
+            let pageRect = page.getBoxRect(.mediaBox)
+            let renderer = UIGraphicsImageRenderer(size: pageRect.size)
+            let image = renderer.image { context in
+                UIColor.white.set()
+                context.fill(pageRect)
+                context.cgContext.translateBy(x: 0, y: pageRect.size.height)
+                context.cgContext.scaleBy(x: 1, y: -1)
+                context.cgContext.drawPDFPage(page)
+            }
+            return image
+        }
+    }
+}

--- a/IAhorro/Services/ReceiptStorageService.swift
+++ b/IAhorro/Services/ReceiptStorageService.swift
@@ -1,0 +1,141 @@
+import Foundation
+import UIKit
+import UniformTypeIdentifiers
+
+actor ReceiptStorageService {
+    enum StorageError: LocalizedError {
+        case failedToCreateDirectory
+        case failedToPersistMetadata
+        case receiptNotFound
+        case failedToDelete
+
+        var errorDescription: String? {
+            switch self {
+            case .failedToCreateDirectory:
+                return "No se pudo crear el directorio de almacenamiento."
+            case .failedToPersistMetadata:
+                return "No se pudo guardar la información de la boleta."
+            case .receiptNotFound:
+                return "Boleta no encontrada."
+            case .failedToDelete:
+                return "No se pudo eliminar el archivo asociado."
+            }
+        }
+    }
+
+    private struct MetadataEnvelope: Codable {
+        var receipts: [Receipt]
+    }
+
+    private let fileManager: FileManager
+    private let metadataURL: URL
+    private let receiptsDirectoryURL: URL
+    private let thumbnailsDirectoryURL: URL
+    private var cachedReceipts: [Receipt] = []
+
+    init(fileManager: FileManager = .default, containerURL: URL? = nil) async throws {
+        self.fileManager = fileManager
+        let container: URL
+        if let containerURL {
+            container = containerURL
+            try fileManager.createDirectory(at: container, withIntermediateDirectories: true, attributes: nil)
+        } else {
+            container = try fileManager.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )
+        }
+        receiptsDirectoryURL = container.appendingPathComponent("Receipts", isDirectory: true)
+        thumbnailsDirectoryURL = container.appendingPathComponent("Thumbnails", isDirectory: true)
+        metadataURL = container.appendingPathComponent("receipts.json", conformingTo: .json)
+
+        try createDirectoriesIfNeeded()
+        try await loadMetadataIfNeeded()
+    }
+
+    // MARK: - Public API
+
+    func loadReceipts() -> [Receipt] {
+        cachedReceipts.sorted(by: { ($0.purchaseDate ?? $0.createdAt) > ($1.purchaseDate ?? $1.createdAt) })
+    }
+
+    func receipt(withId id: Receipt.ID) -> Receipt? {
+        cachedReceipts.first(where: { $0.id == id })
+    }
+
+    func persist(_ receipt: Receipt, data: Data, thumbnail: UIImage?) async throws {
+        let receiptURL = receiptsDirectoryURL.appendingPathComponent(receipt.fileName)
+        try data.write(to: receiptURL, options: .atomic)
+
+        var updatedReceipt = receipt
+        updatedReceipt.fileURL = receiptURL
+
+        if let thumbnail {
+            let thumbnailURL = thumbnailsDirectoryURL.appendingPathComponent("\(receipt.id.uuidString).jpg")
+            guard let jpeg = thumbnail.jpegData(compressionQuality: 0.8) else {
+                throw StorageError.failedToPersistMetadata
+            }
+            try jpeg.write(to: thumbnailURL, options: .atomic)
+            updatedReceipt.thumbnailURL = thumbnailURL
+        }
+
+        if let index = cachedReceipts.firstIndex(where: { $0.id == updatedReceipt.id }) {
+            cachedReceipts[index] = updatedReceipt
+        } else {
+            cachedReceipts.append(updatedReceipt)
+        }
+
+        try persistMetadata()
+    }
+
+    func delete(_ receiptID: Receipt.ID) async throws {
+        guard let index = cachedReceipts.firstIndex(where: { $0.id == receiptID }) else {
+            throw StorageError.receiptNotFound
+        }
+        let receipt = cachedReceipts.remove(at: index)
+
+        do {
+            try fileManager.removeItem(at: receipt.fileURL)
+            if let thumbnailURL = receipt.thumbnailURL {
+                try? fileManager.removeItem(at: thumbnailURL)
+            }
+        } catch {
+            throw StorageError.failedToDelete
+        }
+
+        try persistMetadata()
+    }
+
+    // MARK: - Helpers
+
+    private func createDirectoriesIfNeeded() throws {
+        try fileManager.createDirectory(at: receiptsDirectoryURL, withIntermediateDirectories: true, attributes: nil)
+        try fileManager.createDirectory(at: thumbnailsDirectoryURL, withIntermediateDirectories: true, attributes: nil)
+    }
+
+    private func loadMetadataIfNeeded() async throws {
+        guard fileManager.fileExists(atPath: metadataURL.path) else {
+            cachedReceipts = []
+            return
+        }
+        let data = try Data(contentsOf: metadataURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let envelope = try decoder.decode(MetadataEnvelope.self, from: data)
+        cachedReceipts = envelope.receipts
+    }
+
+    private func persistMetadata() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(MetadataEnvelope(receipts: cachedReceipts))
+        do {
+            try data.write(to: metadataURL, options: .atomic)
+        } catch {
+            throw StorageError.failedToPersistMetadata
+        }
+    }
+}

--- a/IAhorro/Services/ReceiptStore.swift
+++ b/IAhorro/Services/ReceiptStore.swift
@@ -1,0 +1,35 @@
+import Foundation
+import UIKit
+
+@MainActor
+final class ReceiptStore: ObservableObject {
+    @Published private(set) var receipts: [Receipt] = []
+
+    private let storage: ReceiptStorageService
+
+    init(storage: ReceiptStorageService) {
+        self.storage = storage
+        Task {
+            await loadReceipts()
+        }
+    }
+
+    func loadReceipts() async {
+        let loaded = await storage.loadReceipts()
+        receipts = loaded
+    }
+
+    func receipt(withId id: Receipt.ID) async -> Receipt? {
+        await storage.receipt(withId: id)
+    }
+
+    func add(_ receipt: Receipt, data: Data, thumbnail: UIImage?) async throws {
+        try await storage.persist(receipt, data: data, thumbnail: thumbnail)
+        await loadReceipts()
+    }
+
+    func delete(_ receipt: Receipt) async throws {
+        try await storage.delete(receipt.id)
+        await loadReceipts()
+    }
+}

--- a/IAhorro/Utilities/AppEnvironment.swift
+++ b/IAhorro/Utilities/AppEnvironment.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+@MainActor
+struct AppEnvironment {
+    let receiptStore: ReceiptStore
+    let answerService: any ReceiptAnswering
+    let processingService: ReceiptProcessingService
+
+    static func make() async throws -> AppEnvironment {
+        let storage = try await ReceiptStorageService()
+        let store = ReceiptStore(storage: storage)
+        let aiClient: any ReceiptAnswering & ReceiptAnalyzing
+        if let liveService = try? OpenAIService() {
+            aiClient = liveService
+        } else {
+            aiClient = FallbackAIService()
+        }
+        let processing = ReceiptProcessingService(analyzer: aiClient)
+        return AppEnvironment(receiptStore: store, answerService: aiClient, processingService: processing)
+    }
+}

--- a/IAhorro/Utilities/CameraCaptureView.swift
+++ b/IAhorro/Utilities/CameraCaptureView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct CameraCaptureView: UIViewControllerRepresentable {
+    var onCapture: (UIImage) -> Void
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let controller = UIImagePickerController()
+        controller.sourceType = .camera
+        controller.delegate = context.coordinator
+        controller.cameraCaptureMode = .photo
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onCapture: onCapture)
+    }
+
+    final class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        private let onCapture: (UIImage) -> Void
+
+        init(onCapture: @escaping (UIImage) -> Void) {
+            self.onCapture = onCapture
+        }
+
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+            picker.dismiss(animated: true)
+            if let image = info[.originalImage] as? UIImage {
+                onCapture(image)
+            }
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            picker.dismiss(animated: true)
+        }
+    }
+}

--- a/IAhorro/Utilities/DocumentPicker.swift
+++ b/IAhorro/Utilities/DocumentPicker.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct DocumentPicker: UIViewControllerRepresentable {
+    typealias UIViewControllerType = UIDocumentPickerViewController
+
+    var onPick: (URL) -> Void
+
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        let controller = UIDocumentPickerViewController(forOpeningContentTypes: [.image, .pdf, .png, .jpeg, .heif], asCopy: true)
+        controller.delegate = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onPick: onPick)
+    }
+
+    final class Coordinator: NSObject, UIDocumentPickerDelegate {
+        private let onPick: (URL) -> Void
+
+        init(onPick: @escaping (URL) -> Void) {
+            self.onPick = onPick
+        }
+
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            guard let url = urls.first else { return }
+            onPick(url)
+        }
+    }
+}

--- a/IAhorro/Utilities/LocationProvider.swift
+++ b/IAhorro/Utilities/LocationProvider.swift
@@ -1,0 +1,46 @@
+import Foundation
+import CoreLocation
+import Combine
+
+final class LocationProvider: NSObject, ObservableObject {
+    @Published private(set) var location: Geolocation?
+    @Published private(set) var authorizationStatus: CLAuthorizationStatus
+
+    private let manager: CLLocationManager
+
+    override init() {
+        manager = CLLocationManager()
+        authorizationStatus = manager.authorizationStatus
+        super.init()
+        manager.delegate = self
+    }
+
+    func requestLocation() {
+        switch manager.authorizationStatus {
+        case .notDetermined:
+            manager.requestWhenInUseAuthorization()
+        case .authorizedAlways, .authorizedWhenInUse:
+            manager.requestLocation()
+        default:
+            break
+        }
+    }
+}
+
+extension LocationProvider: CLLocationManagerDelegate {
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        authorizationStatus = manager.authorizationStatus
+        if authorizationStatus == .authorizedAlways || authorizationStatus == .authorizedWhenInUse {
+            manager.requestLocation()
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let coordinate = locations.last?.coordinate else { return }
+        location = Geolocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        print("Location error: \(error.localizedDescription)")
+    }
+}

--- a/IAhorro/Utilities/NumberFormatter+Currency.swift
+++ b/IAhorro/Utilities/NumberFormatter+Currency.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension NumberFormatter {
+    static func currencyFormatter(code: String) -> NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = code
+        formatter.maximumFractionDigits = 2
+        return formatter
+    }
+}

--- a/IAhorro/Utilities/PhotoPicker.swift
+++ b/IAhorro/Utilities/PhotoPicker.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+import PhotosUI
+
+struct PhotoPicker: UIViewControllerRepresentable {
+    var onPick: (UIImage, String) -> Void
+
+    func makeUIViewController(context: Context) -> PHPickerViewController {
+        var configuration = PHPickerConfiguration()
+        configuration.filter = .any(of: [.images, .livePhotos])
+        configuration.selectionLimit = 1
+        let picker = PHPickerViewController(configuration: configuration)
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onPick: onPick)
+    }
+
+    final class Coordinator: NSObject, PHPickerViewControllerDelegate {
+        private let onPick: (UIImage, String) -> Void
+
+        init(onPick: @escaping (UIImage, String) -> Void) {
+            self.onPick = onPick
+        }
+
+        func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+            picker.dismiss(animated: true)
+            guard let itemProvider = results.first?.itemProvider else { return }
+            let suggestedName = itemProvider.suggestedName ?? "foto"
+            if itemProvider.canLoadObject(ofClass: UIImage.self) {
+                itemProvider.loadObject(ofClass: UIImage.self) { object, _ in
+                    if let image = object as? UIImage {
+                        DispatchQueue.main.async {
+                            self.onPick(image, suggestedName)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/IAhorro/ViewModels/AddReceiptViewModel.swift
+++ b/IAhorro/ViewModels/AddReceiptViewModel.swift
@@ -1,0 +1,54 @@
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+final class AddReceiptViewModel: ObservableObject {
+    enum AddState: Equatable {
+        case idle
+        case picking
+        case processing
+        case completed
+    }
+
+    @Published var state: AddState = .idle
+    @Published var userDescription: String = ""
+    @Published var location: Geolocation?
+    @Published private(set) var errorMessage: String?
+    @Published private(set) var processedReceipt: Receipt?
+
+    private let receiptStore: ReceiptStore
+    private let processingService: ReceiptProcessingServiceProtocol
+
+    init(receiptStore: ReceiptStore, processingService: ReceiptProcessingServiceProtocol) {
+        self.receiptStore = receiptStore
+        self.processingService = processingService
+    }
+
+    func handlePickedMedia(_ mediaData: Data, mediaType: Receipt.MediaType, originalFileName: String) async {
+        state = .processing
+        do {
+            let processed = try await processingService.process(
+                mediaData: mediaData,
+                mediaType: mediaType,
+                originalFileName: originalFileName,
+                userDescription: userDescription,
+                location: location
+            )
+            try await receiptStore.add(processed.receipt, data: processed.fileData, thumbnail: processed.thumbnail)
+            processedReceipt = processed.receipt
+            state = .completed
+        } catch {
+            errorMessage = error.localizedDescription
+            state = .idle
+        }
+    }
+
+    func reset() {
+        state = .idle
+        userDescription = ""
+        location = nil
+        processedReceipt = nil
+        errorMessage = nil
+    }
+}

--- a/IAhorro/ViewModels/AskAIViewModel.swift
+++ b/IAhorro/ViewModels/AskAIViewModel.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Combine
+
+@MainActor
+final class AskAIViewModel: ObservableObject {
+    @Published var query: String = ""
+    @Published private(set) var answer: String = ""
+    @Published private(set) var isLoading: Bool = false
+    @Published private(set) var errorMessage: String?
+
+    private let receiptStore: ReceiptStore
+    private let answerService: ReceiptAnswering
+
+    init(receiptStore: ReceiptStore, answerService: ReceiptAnswering) {
+        self.receiptStore = receiptStore
+        self.answerService = answerService
+    }
+
+    func submitQuery() async {
+        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            errorMessage = "Escribe una consulta para comenzar."
+            return
+        }
+        isLoading = true
+        errorMessage = nil
+        do {
+            let relevantReceipts = filterReceipts(for: query)
+            answer = try await answerService.answerQuestion(query: query, receipts: relevantReceipts)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    private func filterReceipts(for query: String) -> [Receipt] {
+        let tokens = query.lowercased().components(separatedBy: CharacterSet.alphanumerics.inverted).filter { !$0.isEmpty }
+        return receiptStore.receipts.filter { receipt in
+            let haystack = receipt.keywords + [receipt.merchant.name ?? "", receipt.notes ?? ""]
+            let combined = haystack.joined(separator: " ").lowercased()
+            return tokens.allSatisfy { combined.contains($0) }
+        }
+    }
+}

--- a/IAhorro/ViewModels/InsightsViewModel.swift
+++ b/IAhorro/ViewModels/InsightsViewModel.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Combine
+
+@MainActor
+final class InsightsViewModel: ObservableObject {
+    struct CategorySummary: Identifiable {
+        let id: String
+        let category: ReceiptCategory
+        let total: Decimal
+    }
+
+    @Published private(set) var totalSpent: Decimal = 0
+    @Published private(set) var categorySummaries: [CategorySummary] = []
+    @Published private(set) var keywords: [String] = []
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(receiptPublisher: Published<[Receipt]>.Publisher) {
+        receiptPublisher
+            .sink { [weak self] receipts in
+                self?.computeInsights(from: receipts)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func computeInsights(from receipts: [Receipt]) {
+        totalSpent = receipts.compactMap(\.effectiveTotal).reduce(Decimal(0), +)
+        let grouped = Dictionary(grouping: receipts) { receipt -> ReceiptCategory in
+            receipt.categories.first ?? .other
+        }
+        categorySummaries = grouped.map { category, receipts in
+            let total = receipts.compactMap(\.effectiveTotal).reduce(Decimal(0), +)
+            return CategorySummary(id: category.id, category: category, total: total)
+        }
+        .sorted(by: { $0.total > $1.total })
+
+        let keywordsSet = receipts.flatMap(\.keywords)
+        let counts = keywordsSet.reduce(into: [String: Int]()) { partialResult, keyword in
+            partialResult[keyword, default: 0] += 1
+        }
+        keywords = counts.sorted { lhs, rhs in
+            if lhs.value == rhs.value {
+                return lhs.key < rhs.key
+            }
+            return lhs.value > rhs.value
+        }
+        .map(\.key)
+        .prefix(25)
+        .map(String.init)
+    }
+}

--- a/IAhorro/ViewModels/ReceiptListViewModel.swift
+++ b/IAhorro/ViewModels/ReceiptListViewModel.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Combine
+
+@MainActor
+final class ReceiptListViewModel: ObservableObject {
+    @Published var searchText: String = ""
+    @Published private(set) var receipts: [Receipt] = []
+    @Published private(set) var filteredReceipts: [Receipt] = []
+
+    private let receiptStore: ReceiptStore
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(receiptStore: ReceiptStore) {
+        self.receiptStore = receiptStore
+
+        receiptStore.$receipts
+            .combineLatest($searchText)
+            .map { receipts, searchText in
+                Self.filter(receipts: receipts, query: searchText)
+            }
+            .assign(to: &$filteredReceipts)
+
+        receiptStore.$receipts
+            .assign(to: &$receipts)
+    }
+
+    func refresh() async {
+        await receiptStore.loadReceipts()
+    }
+
+    func delete(_ receipt: Receipt) async throws {
+        try await receiptStore.delete(receipt)
+    }
+
+    private static func filter(receipts: [Receipt], query: String) -> [Receipt] {
+        guard !query.isEmpty else { return receipts }
+        let lowercased = query.lowercased()
+        return receipts.filter { receipt in
+            if receipt.merchant.name?.lowercased().contains(lowercased) == true { return true }
+            if receipt.keywords.contains(where: { $0.lowercased().contains(lowercased) }) { return true }
+            if receipt.categories.contains(where: { $0.displayName.lowercased().contains(lowercased) }) { return true }
+            if receipt.notes?.lowercased().contains(lowercased) == true { return true }
+            return false
+        }
+    }
+}

--- a/IAhorro/Views/AddReceiptSheet.swift
+++ b/IAhorro/Views/AddReceiptSheet.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+struct AddReceiptSheet: View {
+    @ObservedObject var addViewModel: AddReceiptViewModel
+    @Binding var showingDocumentPicker: Bool
+    @Binding var showingPhotoPicker: Bool
+    @Binding var showingCamera: Bool
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Descripción opcional") {
+                    TextField("Ej: almuerzo con clientes", text: $addViewModel.userDescription)
+                        .textInputAutocapitalization(.sentences)
+                }
+
+                Section("Selecciona el origen") {
+                    Button {
+                        showingDocumentPicker = true
+                    } label: {
+                        Label("Archivo existente", systemImage: "folder")
+                    }
+
+                    Button {
+                        showingPhotoPicker = true
+                    } label: {
+                        Label("Foto de la librería", systemImage: "photo.on.rectangle")
+                    }
+
+                    Button {
+                        showingCamera = true
+                    } label: {
+                        Label("Tomar fotografía", systemImage: "camera")
+                    }
+                }
+
+                if let receipt = addViewModel.processedReceipt {
+                    Section("Última boleta agregada") {
+                        ReceiptSummaryView(receipt: receipt)
+                    }
+                }
+            }
+            .navigationTitle("Nueva boleta")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cerrar") {
+                        showingDocumentPicker = false
+                        showingPhotoPicker = false
+                        showingCamera = false
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct ReceiptSummaryView: View {
+    let receipt: Receipt
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(receipt.merchant.name ?? "Comercio sin nombre")
+                .font(.headline)
+            if let date = receipt.purchaseDate {
+                Text(date, style: .date)
+                    .font(.subheadline)
+            }
+            if let total = receipt.effectiveTotal {
+                Text("Total: \(NSDecimalNumber(decimal: total), formatter: NumberFormatter.currencyFormatter(code: receipt.currencyCode))")
+                    .bold()
+            }
+            Text("Etiquetas: \(receipt.categories.map(\.displayName).joined(separator: ", "))")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/IAhorro/Views/AskAIView.swift
+++ b/IAhorro/Views/AskAIView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct AskAIView: View {
+    @ObservedObject var viewModel: AskAIViewModel
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Haz preguntas sobre tus gastos")
+                    .font(.headline)
+                TextField("¿Qué necesitas saber?", text: $viewModel.query, axis: .vertical)
+                    .textFieldStyle(.roundedBorder)
+
+                Button {
+                    Task { await viewModel.submitQuery() }
+                } label: {
+                    Label("Consultar", systemImage: "sparkles")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(viewModel.isLoading)
+
+                if viewModel.isLoading {
+                    ProgressView("Analizando con IA…")
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+
+                if let error = viewModel.errorMessage {
+                    Text(error)
+                        .foregroundStyle(.red)
+                }
+
+                if !viewModel.answer.isEmpty {
+                    ScrollView {
+                        Text(viewModel.answer)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .frame(maxHeight: .infinity)
+                } else {
+                    Spacer()
+                }
+            }
+            .padding()
+            .navigationTitle("Asistente IA")
+        }
+    }
+}

--- a/IAhorro/Views/InsightsView.swift
+++ b/IAhorro/Views/InsightsView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct InsightsView: View {
+    @ObservedObject var viewModel: InsightsViewModel
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    totalsCard
+                    categoriesSection
+                    keywordsSection
+                }
+                .padding()
+            }
+            .navigationTitle("Insights")
+        }
+    }
+
+    private var totalsCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Gasto total")
+                .font(.headline)
+            Text(NSDecimalNumber(decimal: viewModel.totalSpent), formatter: NumberFormatter.currencyFormatter(code: Locale.current.currency?.identifier ?? "USD"))
+                .font(.largeTitle).bold()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 16).fill(Color(.systemGroupedBackground)))
+    }
+
+    private var categoriesSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Por categoría")
+                .font(.headline)
+            ForEach(viewModel.categorySummaries) { summary in
+                HStack {
+                    Label(summary.category.displayName, systemImage: summary.category.iconSystemName)
+                    Spacer()
+                    Text(NSDecimalNumber(decimal: summary.total), formatter: NumberFormatter.currencyFormatter(code: Locale.current.currency?.identifier ?? "USD"))
+                }
+                .padding(.vertical, 8)
+                Divider()
+            }
+        }
+    }
+
+    private var keywordsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Palabras clave destacadas")
+                .font(.headline)
+            if viewModel.keywords.isEmpty {
+                Text("Aún no hay suficientes boletas analizadas.")
+                    .foregroundStyle(.secondary)
+            } else {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 80), spacing: 8)], spacing: 8) {
+                    ForEach(viewModel.keywords, id: \.self) { keyword in
+                        Text(keyword)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(Capsule().fill(Color.green.opacity(0.15)))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/IAhorro/Views/ReceiptDetailView.swift
+++ b/IAhorro/Views/ReceiptDetailView.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+import QuickLook
+
+struct ReceiptDetailView: View {
+    let receipt: Receipt
+    @State private var quickLookURL: URL?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                header
+                totalsSection
+                lineItemsSection
+                keywordsSection
+                notesSection
+                metadataSection
+            }
+            .padding()
+        }
+        .navigationTitle(receipt.merchant.name ?? "Detalle")
+        .toolbar {
+            ToolbarItemGroup(placement: .primaryAction) {
+                Button {
+                    quickLookURL = receipt.fileURL
+                } label: {
+                    Label("Ver archivo", systemImage: "doc.text.magnifyingglass")
+                }
+            }
+        }
+        .quickLookPreview($quickLookURL)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(receipt.merchant.name ?? "Comercio sin nombre")
+                .font(.largeTitle).bold()
+            if let purchaseDate = receipt.purchaseDate {
+                Text(purchaseDate.formatted(date: .long, time: .shortened))
+                    .font(.headline)
+            }
+            HStack(spacing: 8) {
+                ForEach(receipt.categories) { category in
+                    Label(category.displayName, systemImage: category.iconSystemName)
+                        .labelStyle(.titleAndIcon)
+                        .font(.caption)
+                        .padding(6)
+                        .background(Capsule().fill(Color.blue.opacity(0.1)))
+                }
+            }
+        }
+    }
+
+    private var totalsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let subtotal = receipt.taxBreakdown.subtotal {
+                HStack {
+                    Text("Subtotal")
+                    Spacer()
+                    Text(NSDecimalNumber(decimal: subtotal), formatter: NumberFormatter.currencyFormatter(code: receipt.currencyCode))
+                }
+            }
+            if let tax = receipt.taxBreakdown.tax {
+                HStack {
+                    Text("IVA")
+                    Spacer()
+                    Text(NSDecimalNumber(decimal: tax), formatter: NumberFormatter.currencyFormatter(code: receipt.currencyCode))
+                }
+            }
+            if let total = receipt.effectiveTotal {
+                HStack {
+                    Text("Total")
+                        .bold()
+                    Spacer()
+                    Text(NSDecimalNumber(decimal: total), formatter: NumberFormatter.currencyFormatter(code: receipt.currencyCode))
+                        .bold()
+                }
+            }
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 12).fill(Color(.systemGroupedBackground)))
+    }
+
+    private var lineItemsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if receipt.lineItems.isEmpty {
+                EmptyView()
+            } else {
+                Text("Detalle de productos")
+                    .font(.headline)
+                ForEach(receipt.lineItems) { item in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(item.description)
+                            .font(.subheadline)
+                        HStack {
+                            if let quantity = item.quantity {
+                                Text("Cantidad: \(quantity, specifier: "%.2f")")
+                            }
+                            Spacer()
+                            if let total = item.total {
+                                Text(NSDecimalNumber(decimal: total), formatter: NumberFormatter.currencyFormatter(code: receipt.currencyCode))
+                            }
+                        }
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    }
+                    Divider()
+                }
+            }
+        }
+    }
+
+    private var keywordsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if receipt.keywords.isEmpty {
+                EmptyView()
+            } else {
+                Text("Palabras clave")
+                    .font(.headline)
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 100), spacing: 8)], spacing: 8) {
+                    ForEach(receipt.keywords.sorted(), id: \.self) { keyword in
+                        Text(keyword)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(Capsule().fill(Color.orange.opacity(0.15)))
+                    }
+                }
+            }
+        }
+    }
+
+    private var notesSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let notes = receipt.notes {
+                Text("Notas de IA")
+                    .font(.headline)
+                Text(notes)
+                    .font(.body)
+            }
+        }
+    }
+
+    private var metadataSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Metadatos")
+                .font(.headline)
+            if let location = receipt.location {
+                Text("Ubicación aproximada: lat \(location.latitude), lon \(location.longitude)")
+            }
+            Text("Creado: \(receipt.createdAt.formatted())")
+            Text("Archivo: \(receipt.fileName)")
+        }
+    }
+}

--- a/IAhorro/Views/ReceiptListView.swift
+++ b/IAhorro/Views/ReceiptListView.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+import UIKit
+
+struct ReceiptListView: View {
+    @ObservedObject var viewModel: ReceiptListViewModel
+    let receiptStore: ReceiptStore
+    @State private var showingAddSheet = false
+    @State private var showingDocumentPicker = false
+    @State private var showingPhotoPicker = false
+    @State private var showingCamera = false
+    @StateObject private var addViewModel: AddReceiptViewModel
+    @StateObject private var locationProvider = LocationProvider()
+    init(viewModel: ReceiptListViewModel, processingService: ReceiptProcessingServiceProtocol, receiptStore: ReceiptStore) {
+        self.viewModel = viewModel
+        self.receiptStore = receiptStore
+        _addViewModel = StateObject(wrappedValue: AddReceiptViewModel(receiptStore: receiptStore, processingService: processingService))
+    }
+
+    var body: some View {
+        List {
+            if viewModel.filteredReceipts.isEmpty {
+                ContentUnavailableView("Sin boletas", systemImage: "doc") {
+                    Text("Agrega tu primera boleta desde el botón +.")
+                }
+            } else {
+                ForEach(viewModel.filteredReceipts) { receipt in
+                    NavigationLink(destination: ReceiptDetailView(receipt: receipt)) {
+                        ReceiptRowView(receipt: receipt)
+                    }
+                }
+                .onDelete { indexSet in
+                    Task {
+                        let receiptsToDelete = indexSet.compactMap { index in
+                            viewModel.filteredReceipts.indices.contains(index) ? viewModel.filteredReceipts[index] : nil
+                        }
+                        for receipt in receiptsToDelete {
+                            try? await viewModel.delete(receipt)
+                        }
+                    }
+                }
+            }
+        }
+        .refreshable {
+            await viewModel.refresh()
+        }
+        .searchable(text: $viewModel.searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Buscar por palabras clave o comercio")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showingAddSheet = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .accessibilityLabel("Agregar boleta")
+            }
+        }
+        .sheet(isPresented: $showingAddSheet) {
+            AddReceiptSheet(addViewModel: addViewModel, showingDocumentPicker: $showingDocumentPicker, showingPhotoPicker: $showingPhotoPicker, showingCamera: $showingCamera)
+                .presentationDetents([.medium, .large])
+        }
+        .sheet(isPresented: $showingDocumentPicker) {
+            DocumentPicker { url in
+                Task {
+                    await handlePickedURL(url)
+                }
+            }
+        }
+        .sheet(isPresented: $showingPhotoPicker) {
+            PhotoPicker { image, name in
+                Task {
+                    await handlePickedImage(image, suggestedName: name)
+                }
+            }
+        }
+        .sheet(isPresented: $showingCamera) {
+            CameraCaptureView { image in
+                Task {
+                    await handlePickedImage(image, suggestedName: "captura")
+                }
+            }
+        }
+        .onAppear {
+            locationProvider.requestLocation()
+        }
+        .onReceive(locationProvider.$location) { location in
+            addViewModel.location = location
+        }
+        .onChange(of: showingDocumentPicker) { newValue in
+            if newValue { showingAddSheet = false }
+        }
+        .onChange(of: showingPhotoPicker) { newValue in
+            if newValue { showingAddSheet = false }
+        }
+        .onChange(of: showingCamera) { newValue in
+            if newValue { showingAddSheet = false }
+        }
+        .alert("Error", isPresented: Binding(get: { addViewModel.errorMessage != nil }, set: { _ in addViewModel.errorMessage = nil })) {
+            Button("Entendido", role: .cancel) {}
+        } message: {
+            if let message = addViewModel.errorMessage {
+                Text(message)
+            }
+        }
+    }
+
+    private func handlePickedURL(_ url: URL) async {
+        showingAddSheet = false
+        showingDocumentPicker = false
+        do {
+            let data = try Data(contentsOf: url)
+            let mediaType: Receipt.MediaType = (url.pathExtension.lowercased() == "pdf") ? .pdf : .image
+            await addViewModel.handlePickedMedia(data, mediaType: mediaType, originalFileName: url.lastPathComponent)
+        } catch {
+            addViewModel.errorMessage = error.localizedDescription
+        }
+    }
+
+    private func handlePickedImage(_ image: UIImage, suggestedName: String) async {
+        showingAddSheet = false
+        showingPhotoPicker = false
+        showingCamera = false
+        guard let data = image.jpegData(compressionQuality: 0.95) else { return }
+        await addViewModel.handlePickedMedia(data, mediaType: .image, originalFileName: "\(suggestedName).jpg")
+    }
+}

--- a/IAhorro/Views/ReceiptRowView.swift
+++ b/IAhorro/Views/ReceiptRowView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+import UIKit
+
+struct ReceiptRowView: View {
+    let receipt: Receipt
+
+    var body: some View {
+        HStack(spacing: 16) {
+            if let thumbnailURL = receipt.thumbnailURL, let image = UIImage(contentsOfFile: thumbnailURL.path) {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 60, height: 60)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .accessibilityHidden(true)
+            } else {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.blue.opacity(0.1))
+                    .frame(width: 60, height: 60)
+                    .overlay(
+                        Image(systemName: receipt.mediaType == .pdf ? "doc.richtext" : "photo")
+                            .font(.title3)
+                            .foregroundStyle(.blue)
+                    )
+                    .accessibilityHidden(true)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(receipt.merchant.name ?? "Comercio sin nombre")
+                    .font(.headline)
+                if let purchaseDate = receipt.purchaseDate {
+                    Text(purchaseDate, format: .dateTime.day().month().year())
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Text(receipt.categories.map(\.displayName).joined(separator: ", "))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            if let total = receipt.effectiveTotal {
+                Text(NSDecimalNumber(decimal: total), formatter: NumberFormatter.currencyFormatter(code: receipt.currencyCode))
+                    .font(.headline)
+            }
+        }
+        .padding(.vertical, 8)
+    }
+}

--- a/IAhorro/Views/RootView.swift
+++ b/IAhorro/Views/RootView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct RootView: View {
+    @EnvironmentObject private var receiptStore: ReceiptStore
+    @StateObject private var listViewModel: ReceiptListViewModel
+    @StateObject private var insightsViewModel: InsightsViewModel
+    @StateObject private var askAIViewModel: AskAIViewModel
+    init(answerService: ReceiptAnswering, processingService: ReceiptProcessingServiceProtocol, receiptStore: ReceiptStore) {
+        _listViewModel = StateObject(wrappedValue: ReceiptListViewModel(receiptStore: receiptStore))
+        _insightsViewModel = StateObject(wrappedValue: InsightsViewModel(receiptPublisher: receiptStore.$receipts))
+        _askAIViewModel = StateObject(wrappedValue: AskAIViewModel(receiptStore: receiptStore, answerService: answerService))
+        self.processingService = processingService
+        self.receiptStore = receiptStore
+    }
+    private let processingService: ReceiptProcessingServiceProtocol
+    private let receiptStore: ReceiptStore
+
+    var body: some View {
+        TabView {
+            NavigationStack {
+                ReceiptListView(viewModel: listViewModel, processingService: processingService, receiptStore: receiptStore)
+                    .navigationTitle("Boletas")
+            }
+            .tabItem {
+                Label("Boletas", systemImage: "doc.richtext")
+            }
+
+            InsightsView(viewModel: insightsViewModel)
+                .tabItem {
+                    Label("Insights", systemImage: "chart.pie.fill")
+                }
+
+            AskAIView(viewModel: askAIViewModel)
+                .tabItem {
+                    Label("IA", systemImage: "sparkles")
+                }
+        }
+    }
+}

--- a/IAhorroTests/ReceiptProcessingServiceTests.swift
+++ b/IAhorroTests/ReceiptProcessingServiceTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+import UIKit
+@testable import IAhorro
+
+final class ReceiptProcessingServiceTests: XCTestCase {
+    func testProcessEnrichesKeywordsAndCategories() async throws {
+        let analyzer = MockAnalyzer()
+        let service = ReceiptProcessingService(analyzer: analyzer)
+        let description = "Consulta médica por dolor estomacal en Viña del Mar"
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 32, height: 32))
+        let image = renderer.image { ctx in
+            UIColor.systemBlue.setFill()
+            ctx.fill(CGRect(origin: .zero, size: CGSize(width: 32, height: 32)))
+        }
+        let data = image.jpegData(compressionQuality: 0.8)!
+
+        let processed = try await service.process(
+            mediaData: data,
+            mediaType: .image,
+            originalFileName: "consulta.png",
+            userDescription: description,
+            location: Geolocation(latitude: -33.0, longitude: -71.5)
+        )
+
+        XCTAssertEqual(Set(processed.receipt.keywords).contains("dolor"), true)
+        XCTAssertTrue(processed.receipt.categories.contains(.health))
+        XCTAssertEqual(processed.receipt.mediaType, .image)
+        XCTAssertNotNil(processed.thumbnail)
+    }
+}
+
+private struct MockAnalyzer: ReceiptAnalyzing {
+    func analyzeReceipt(mediaData: Data, mediaType: Receipt.MediaType, userDescription: String?, location: Geolocation?) async throws -> ReceiptAnalysisResult {
+        ReceiptAnalysisResult(
+            merchant: .init(name: "Clínica Mayo", contact: nil, address: "Viña del Mar"),
+            payer: .init(name: "Juan Pérez", contact: nil, address: nil),
+            purchaseDate: Date(timeIntervalSince1970: 0),
+            taxBreakdown: .init(subtotal: 10000, tax: 1900, total: 11900),
+            currencyCode: "CLP",
+            keywords: ["salud", "consulta", "medico"],
+            categories: ["health"],
+            lineItems: [ReceiptAnalysisResult.LineItem(description: "Consulta gastroenterología", quantity: 1, unitPrice: 10000, total: 10000)],
+            notes: "Consulta por dolor estomacal",
+            aiSummary: "Atención médica general"
+        )
+    }
+}

--- a/IAhorroTests/ReceiptStorageServiceTests.swift
+++ b/IAhorroTests/ReceiptStorageServiceTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import IAhorro
+
+final class ReceiptStorageServiceTests: XCTestCase {
+    func testPersistAndLoadReceipts() async throws {
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+        let storage = try await ReceiptStorageService(containerURL: tempURL)
+        let receipt = Receipt(
+            purchaseDate: Date(timeIntervalSince1970: 0),
+            merchant: .init(name: "Supermercado Central", contact: nil, address: nil),
+            taxBreakdown: .init(subtotal: 1000, tax: 190, total: 1190),
+            currencyCode: "CLP",
+            mediaType: .image,
+            fileName: "super.jpg",
+            fileURL: tempURL,
+            keywords: ["supermercado", "comida"],
+            categories: [.groceries]
+        )
+
+        try await storage.persist(receipt, data: Data([0x0]), thumbnail: nil)
+        let receipts = await storage.loadReceipts()
+        XCTAssertEqual(receipts.count, 1)
+        XCTAssertEqual(receipts.first?.keywords.sorted(), ["comida", "supermercado"])
+        XCTAssertEqual(receipts.first?.categories, [.groceries])
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# IAhorro
+
+IAhorro es una aplicación iOS construida con SwiftUI que digitaliza boletas y facturas usando IA para clasificar gastos personales. Esta versión incluye:
+
+- Captura de boletas desde archivos, biblioteca de fotos o cámara.
+- Procesamiento asistido por OpenAI (con modo sin conexión) para extraer metadatos, palabras clave y categorías.
+- Almacenamiento local cifrable mediante el gestor de archivos del dispositivo.
+- Resúmenes de gastos por categoría, palabras clave destacadas y respuestas conversacionales.
+
+## Requisitos
+
+- Xcode 15 o superior.
+- iOS 17 como destino mínimo.
+- Configura las claves de OpenAI en `Info.plist` (`OPENAI_API_KEY` y opcionalmente `OPENAI_ORG_ID`) para habilitar el análisis avanzado. Sin clave la app usará un modo local degradado.
+
+## Configuración
+
+1. Abre `IAhorro.xcodeproj` en Xcode.
+2. Reemplaza los valores de API en el esquema si deseas usar OpenAI.
+3. Ejecuta las pruebas con `Cmd + U`.
+
+## Pruebas
+
+Se incluyen pruebas unitarias para el servicio de procesamiento de boletas y el almacenamiento local. Ejecuta:
+
+```bash
+xcodebuild test -scheme IAhorro -destination 'platform=iOS Simulator,name=iPhone 15'
+```
+
+## Seguridad
+
+- Los archivos se almacenan en `Application Support/Receipts` y pueden sincronizarse con iCloud si se habilita en el proyecto.
+- No se envían datos a OpenAI si no se proporcionan credenciales.
+
+## Licencia
+
+MIT


### PR DESCRIPTION
## Summary
- implement receipt domain models, storage actor, and AI service abstractions with a fallback offline analyzer
- build SwiftUI interface for capturing, browsing, and analyzing receipts including insights dashboards and IA assistant
- add unit tests for receipt processing and storage plus project documentation in README

## Testing
- `xcodebuild test -scheme IAhorro -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d477b19cc0832f938ed232a6fb8990